### PR TITLE
Add underline under the game page links

### DIFF
--- a/src/components/GameNav/GameNav.scss
+++ b/src/components/GameNav/GameNav.scss
@@ -1,75 +1,124 @@
 @use '../../colors' as *;
 
 .game-nav__wrapper {
-    height: 100px;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  height: 100px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-    .wideUl {
-        width: 100vw;
-        background-color: $color-light-black;
-        position: absolute;
-        left: -10vw;
-        display: flex;
-        align-items: center;
-        justify-content: space-around;
-
-    }
-
-    .wideUl,
-    .smallUl {
-        margin-bottom: 5vw;
-
-        li {
-            a {
-                border: none;
-                background-color: transparent;
-                cursor: pointer;
-
-                img {
-                    max-width: 130px;
-                    width: 100%;
-                }
-            }
-        }
-    }
-}
-
-
-.smallUl {
+  .wideUl {
     width: 100vw;
     background-color: $color-light-black;
     position: absolute;
     left: -10vw;
-    --gap: 1rem;
-    display: grid;
-    gap: var(--gap);
-    grid-auto-flow: column;
-    grid-auto-columns: calc(50% - (var(--gap) / 2));
-    overflow-y: scroll;
-    scroll-snap-type: x mandatory;
-    -ms-scroll-snap-type: x;
-    scroll-padding: var(--gap);
-
-    :first-child {
-        padding-left: .5rem;
-    }
-
-    :last-child {
-        padding-right: .5rem;
-    }
-
-}
-
-.smallUl>* {
-    scroll-snap-align: start;
     display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: space-around;
+
+    li {
+      a {
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
+
+        img {
+          max-width: 130px;
+          width: 100%;
+        }
+
+        #game-nav{
+            position: relative;
+        }
+      }
+    }
+  }
+
+  .wideUl,
+  .smallUl {
+    margin-bottom: 5vw;
+
+    li {
+      a {
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
+
+        img {
+          max-width: 130px;
+          width: 100%;
+        }
+      }
+    }
+  }
 }
 
-.active {
-    background-color: blue;
+.smallUl {
+  width: 100vw;
+  background-color: $color-light-black;
+  position: absolute;
+  left: -10vw;
+  --gap: 1rem;
+  display: grid;
+  gap: var(--gap);
+  grid-auto-flow: column;
+  grid-auto-columns: calc(50% - (var(--gap) / 2));
+  overflow-y: scroll;
+  scroll-snap-type: x mandatory;
+  -ms-scroll-snap-type: x;
+  scroll-padding: var(--gap);
+
+  :first-child {
+    padding-left: 0.5rem;
+  }
+
+  :last-child {
+    padding-right: 0.5rem;
+  }
+}
+
+.smallUl > * {
+  scroll-snap-align: start;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .underline {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%; 
+    height: 2px; 
+    background-color: $color-orange; 
+    transform: scaleX(0); 
+    transform-origin: right; 
+
+    transition: transform 0.3s ease; 
+  }
+
+  &:hover .underline {
+    transform: scaleX(1); 
+    transform-origin: left; 
+  }
+}
+
+.active-link {
+    text-decoration: underline;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    position: relative;
+    .underline {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%; 
+        height: 6px; 
+        background-color: $color-orange; 
+      }
+
+      &:hover .underline {
+        transform: scaleX(1); 
+        transform-origin: left; 
+      }
 }

--- a/src/components/GameNav/GameNav.tsx
+++ b/src/components/GameNav/GameNav.tsx
@@ -9,7 +9,6 @@ import Boss from "./Tab/Boss";
 
 export default function GameNav() {
   const [tab, setTab] = useState("bigtime");
-
   const [isWideScreen, setIsWideScreen] = useState(false);
 
   useEffect(() => {
@@ -24,31 +23,34 @@ export default function GameNav() {
       window.removeEventListener("resize", handleResize);
     };
   }, []);
+
+  const handleTabClick = (newTab) => {
+    setTab(newTab);
+  };
+
   return (
     <>
       <div className="game-nav__wrapper">
-        <ul id="game-nav" className={isWideScreen ? `wideUl` : "smallUl"}>
-          <li className="">
-            <a onClick={() => setTab("bigtime")} href="#game-nav">
+        <ul id="game-nav" className={`game-tabs ${isWideScreen ? "wideUl" : "smallUl"}`}>
+          <li className={tab === "bigtime" ? "active-link" : ""}>
+            <a onClick={() => handleTabClick("bigtime")} href="#game-nav">
               <img
-                src={`${
-                  import.meta.env.CDN_URL
-                }/images/assets/gameLogo/BigT.png`}
+                src={`${import.meta.env.CDN_URL}/images/assets/gameLogo/BigT.png`}
                 alt=""
               />
+               <span className="underline"></span>
             </a>
           </li>
-          <li>
-            <a onClick={() => setTab("reign")} href="#game-nav">
+          <li className={tab === "reign" ? "active-link" : ""}>
+            <a onClick={() => handleTabClick("reign")} href="#game-nav">
               <img
-                src={`${
-                  import.meta.env.CDN_URL
-                }/images/assets/gameLogo/ReignO.png`}
+                src={`${import.meta.env.CDN_URL}/images/assets/gameLogo/ReignO.png`}
                 alt=""
               />
+                <span className="underline"></span>
             </a>
           </li>
-          <li>
+          <li className={tab === "desol" ? "active-link" : ""}>
             <a onClick={() => setTab("desol")} href="#game-nav">
               <img
                 src={`${
@@ -56,9 +58,10 @@ export default function GameNav() {
                 }/images/assets/gameLogo/DesoL.png`}
                 alt=""
               />
+                <span className="underline"></span>
             </a>
           </li>
-          <li>
+          <li className={tab === "shatter" ? "active-link" : ""}>
             <a onClick={() => setTab("shatter")} href="#game-nav">
               <img
                 src={`${
@@ -66,9 +69,10 @@ export default function GameNav() {
                 }/images/assets/gameLogo/ShatterP.webp`}
                 alt=""
               />
+               <span className="underline"></span>
             </a>
           </li>
-          <li>
+          <li className={tab === "boss" ? "active-link" : ""}>
             <a onClick={() => setTab("boss")} href="#game-nav">
               <img
                 src={`${
@@ -76,9 +80,10 @@ export default function GameNav() {
                 }/images/assets/gameLogo/BossF.png`}
                 alt=""
               />
+                <span className="underline"></span>
             </a>
           </li>
-          <li>
+          <li className={tab === "world" ? "active-link" : ""}>
             <a onClick={() => setTab("world")} href="#game-nav">
               <img
                 src={`${
@@ -86,6 +91,7 @@ export default function GameNav() {
                 }/images/assets/gameLogo/WorldS.png`}
                 alt=""
               />
+                <span className="underline"></span>
             </a>
           </li>
         </ul>

--- a/src/components/GameNav/GameNav.tsx
+++ b/src/components/GameNav/GameNav.tsx
@@ -24,10 +24,10 @@ export default function GameNav() {
     };
   }, []);
 
-  const handleTabClick = (newTab) => {
+  const handleTabClick = (newTab: string) => {
     setTab(newTab);
   };
-
+  
   return (
     <>
       <div className="game-nav__wrapper">

--- a/src/components/GameNav/Tab/Bigtime.tsx
+++ b/src/components/GameNav/Tab/Bigtime.tsx
@@ -1,3 +1,5 @@
+import "../../Sections/Sections.scss";
+
 export default function Bigtime() {
   return (
     <>

--- a/src/components/GameNav/Tab/Boss.tsx
+++ b/src/components/GameNav/Tab/Boss.tsx
@@ -2,7 +2,7 @@ import "../../Sections/Sections.scss";
 
 export default function Boss() {
   return (
-    <section className="game-section__wrapper">
+    <section className="game-section__wrapper game__container">
       <div className="content__wrapper">
         <div className="text__wrapper">
           <h3>BE THE BOSS IN VR</h3>
@@ -22,3 +22,5 @@ export default function Boss() {
     </section>
   );
 }
+
+// /!\ Supprimer la class game__container en cas d'ajout de contenue /!\

--- a/src/components/GameNav/Tab/Desol.tsx
+++ b/src/components/GameNav/Tab/Desol.tsx
@@ -1,6 +1,8 @@
+import "../../Sections/Sections.scss";
+
 export default function Desol() {
   return (
-    <section className="game-section__wrapper">
+    <section className="game-section__wrapper game__container">
       <div className="content__wrapper">
         <div className="text__wrapper">
           <h3>DESOLATION </h3>
@@ -20,3 +22,5 @@ export default function Desol() {
     </section>
   );
 }
+
+// /!\ Supprimer la class game__container en cas d'ajout de contenue /!\

--- a/src/components/GameNav/Tab/Reign.tsx
+++ b/src/components/GameNav/Tab/Reign.tsx
@@ -1,6 +1,8 @@
+import "../../Sections/Sections.scss";
+
 export default function Reign() {
   return (
-    <section className="game-section__wrapper" id="reign">
+    <section className="game-section__wrapper game__container" id="reign">
       <div className="content__wrapper">
         <div className="text__wrapper">
           <h3>Reign of Terror is an epic cyberpunk game</h3>
@@ -24,3 +26,5 @@ export default function Reign() {
     </section>
   );
 }
+
+// /!\ Supprimer la class game__container en cas d'ajout de contenue /!\

--- a/src/components/GameNav/Tab/Shatter.tsx
+++ b/src/components/GameNav/Tab/Shatter.tsx
@@ -1,6 +1,8 @@
+import "../../Sections/Sections.scss";
+
 export default function Shatter() {
   return (
-    <section className="game-section__wrapper" id="shatter">
+    <section className="game-section__wrapper game__container" id="shatter">
       <div className="content__wrapper">
         <div className="text__wrapper">
           <h3>Shatter Point</h3>
@@ -22,3 +24,5 @@ export default function Shatter() {
     </section>
   );
 }
+
+// /!\ Supprimer la class game__container en cas d'ajout de contenue /!\

--- a/src/components/GameNav/Tab/World.tsx
+++ b/src/components/GameNav/Tab/World.tsx
@@ -1,6 +1,8 @@
+import "../../Sections/Sections.scss";
+
 export default function World() {
   return (
-    <section className="game-section__wrapper" id="world">
+    <section className="game-section__wrapper game__container" id="world">
       <div className="content__wrapper">
         <div className="text__wrapper">
           <h3>World Shards</h3>
@@ -20,3 +22,5 @@ export default function World() {
     </section>
   );
 }
+
+// /!\ Supprimer la class game__container en cas d'ajout de contenue /!\

--- a/src/components/Sections/Sections.scss
+++ b/src/components/Sections/Sections.scss
@@ -217,5 +217,8 @@
   }
 }
 
+.game__container{
+  height: calc(100vh - 300px);
+}
 
 

--- a/src/components/common/footer/Footer.scss
+++ b/src/components/common/footer/Footer.scss
@@ -11,7 +11,7 @@ footer {
   position: relative;
   bottom: 0;
   width: 100%;
-  height: 100%;
+  height: 100px;
 
   a {
     color: $color-gray;

--- a/src/components/common/footer/Footer.tsx
+++ b/src/components/common/footer/Footer.tsx
@@ -6,8 +6,8 @@ export default function Footer() {
       <div className="footer__wrapper">
         <ul className="footer__links">
           <li><a href="/">Terms of use</a></li>
-          <li><a href="/">Public Deck</a></li>
-          <li><a href="/">Launchpad</a></li>
+          <li><a href="/">Team Github</a></li>
+          <li><a href="/">Oracle</a></li>
           <li><a href="/">About us</a></li>
         </ul>
       </div>

--- a/src/components/common/nav/Nav.scss
+++ b/src/components/common/nav/Nav.scss
@@ -10,8 +10,10 @@ nav {
     align-items: center;
 
     a {
-
       font-size: clamp(.5rem, 2vw, 1.2rem);
+      text-decoration: none; // Pour supprimer le soulignement par défaut
+      color: inherit; // Utilisez la couleur par défaut du texte
+
     }
 
     img {

--- a/src/components/common/nav/Nav.tsx
+++ b/src/components/common/nav/Nav.tsx
@@ -15,12 +15,12 @@ export default function Nav() {
           />
         </a>
         <ul className="nav__ul">
-          <Link to="/">Home</Link>
-          <Link to="/about_dao">About DAO</Link>
-          <Link to="/about_us">About us</Link>
-          <Link to="/games">Games</Link>
+          <Link to="/">Accueil</Link>
+          <Link to="/about_dao">À propos</Link>
+          <Link to="/about_us">Guilde</Link>
+          <Link to="/games">Jeux</Link>
         </ul>
-        <CTAButton text={"Join the team"} />
+        <CTAButton text={"Rejoignez nous"} />
       </div>
     </nav>
   );


### PR DESCRIPTION
I added underlining of the links on the game page as well as adjusting the height so that we can see the navGame + the content and the footer. Added a comment (important) in the components: Tab>Boss, Desol, Reign, Shatter, World.